### PR TITLE
Lang list update

### DIFF
--- a/tk_barrydegraaff_zimbra_openpgp/tk_barrydegraaff_zimbra_openpgp.js
+++ b/tk_barrydegraaff_zimbra_openpgp/tk_barrydegraaff_zimbra_openpgp.js
@@ -419,12 +419,25 @@ function(id, title, message) {
       break;
    case 3:
       //Manage keys
+      langListName = ['Nederlands','English','Italiano','Español','Tiếng Việt'];
+      langListValue = ['dutch','english','italian','spanish','vietnamese'];
+      
+      langListHtml = "<select id='zimbra_openpgp_language' name='zimbra_openpgp_language'>";
+      for (i = 0; i < langListValue.length; i++) {
+      	if (langListValue[i] == tk_barrydegraaff_zimbra_openpgp.settings['language']) {
+	      	langListHtml += "<option value=\"" + langListValue[i] + "\" selected=\"selected\">" + langListName[i] + "</option>";
+	      else
+	      	langListHtml += "<option value=\"" + langListValue[i] + "\">" + langListName[i] + "</option>";
+	      }
+      }
+      langListHtml += "</selected>";
+      	 
       html = "<div style='width:650px; height: 500px; overflow-x: hidden; overflow-y: scroll;'><table><tr><td colspan='2'>" +
       "<ul>"+tk_barrydegraaff_zimbra_openpgp.lang[tk_barrydegraaff_zimbra_openpgp.settings['language']][22]+"</ul><br>" +
       "</td></tr>" +      
       "<tr><td style=\"width:100px\">"+tk_barrydegraaff_zimbra_openpgp.lang[tk_barrydegraaff_zimbra_openpgp.settings['language']][19]+":</td><td style=\"width:500px\">"+tk_barrydegraaff_zimbra_openpgp.lang[tk_barrydegraaff_zimbra_openpgp.settings['language']][25]+"<textarea class=\"barrydegraaff_zimbra_openpgp-input\" rows=\"3\" cols=\"65\" id='privateKeyInput'/>" + (localStorage['zimbra_openpgp_privatekey'+tk_barrydegraaff_zimbra_openpgp.prototype.getUsername()] ? localStorage['zimbra_openpgp_privatekey'+tk_barrydegraaff_zimbra_openpgp.prototype.getUsername()] : '') + "</textarea></td></tr>" +
       "<tr><td>"+tk_barrydegraaff_zimbra_openpgp.lang[tk_barrydegraaff_zimbra_openpgp.settings['language']][20]+":</td><td><br>"+tk_barrydegraaff_zimbra_openpgp.lang[tk_barrydegraaff_zimbra_openpgp.settings['language']][24]+"<input class=\"barrydegraaff_zimbra_openpgp-input\" id='privatePassInput' type='password' value='" + (this.getUserPropertyInfo("zimbra_openpgp_privatepass").value ? this.getUserPropertyInfo("zimbra_openpgp_privatepass").value : '') + "'></td></tr>" +
-      "<tr><td><br>"+tk_barrydegraaff_zimbra_openpgp.lang[tk_barrydegraaff_zimbra_openpgp.settings['language']][23]+":</td><td><br><select id='zimbra_openpgp_language' name='zimbra_openpgp_language'><option>" + tk_barrydegraaff_zimbra_openpgp.settings['language'] + "</option><option>dutch</option><option>english</option><option>italian</option><option>spanish</option><option>vietnamese</option>" + "</select></td></tr>" +
+      "<tr><td><br>"+tk_barrydegraaff_zimbra_openpgp.lang[tk_barrydegraaff_zimbra_openpgp.settings['language']][23]+":</td><td><br>" + langListHtml + "</td></tr>" +
       "<tr><td><br>"+tk_barrydegraaff_zimbra_openpgp.lang[tk_barrydegraaff_zimbra_openpgp.settings['language']][27]+":</td><td><br><input type='checkbox' id='enable_contacts_scanning' name='enable_contacts_scanning' " + (tk_barrydegraaff_zimbra_openpgp.settings['enable_contacts_scanning']=='false' ? '' : 'checked') + " value='true'>" + "</td></tr>" +
       "<tr><td>"+tk_barrydegraaff_zimbra_openpgp.lang[tk_barrydegraaff_zimbra_openpgp.settings['language']][26]+" 1:</td><td><br><textarea class=\"barrydegraaff_zimbra_openpgp-input\" rows=\"3\" cols=\"65\" id='publicKeyInput1'/>" + (this.getUserPropertyInfo("zimbra_openpgp_pubkeys1").value ? this.getUserPropertyInfo("zimbra_openpgp_pubkeys1").value : '') + "</textarea></td></tr>" +
       "<tr><td>"+tk_barrydegraaff_zimbra_openpgp.lang[tk_barrydegraaff_zimbra_openpgp.settings['language']][26]+" 2:</td><td><textarea class=\"barrydegraaff_zimbra_openpgp-input\" rows=\"3\" cols=\"65\" id='publicKeyInput2'/>" + (this.getUserPropertyInfo("zimbra_openpgp_pubkeys2").value ? this.getUserPropertyInfo("zimbra_openpgp_pubkeys2").value : '') + "</textarea></td></tr>" +

--- a/tk_barrydegraaff_zimbra_openpgp/tk_barrydegraaff_zimbra_openpgp.js
+++ b/tk_barrydegraaff_zimbra_openpgp/tk_barrydegraaff_zimbra_openpgp.js
@@ -426,7 +426,7 @@ function(id, title, message) {
       for (i = 0; i < langListValue.length; i++) {
       	if (langListValue[i] == tk_barrydegraaff_zimbra_openpgp.settings['language']) {
 	      	langListHtml += "<option value=\"" + langListValue[i] + "\" selected=\"selected\">" + langListName[i] + "</option>";
-	      else
+	      } else {
 	      	langListHtml += "<option value=\"" + langListValue[i] + "\">" + langListName[i] + "</option>";
 	      }
       }


### PR DESCRIPTION
Some people don't use English so it's better for them to read their language in that particular language, not English.

This hack is to update the language list in "Manage Keys" dialog:
* to show the real language name (in that particular language)
* to remove duplicated "selected" option